### PR TITLE
Apply v0.9 changes to in progress v1.0-RC1 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 *.csv
 *.log
 *.txt
+.DS_Store
 .bundle
 .history
+.ruby-version
+.vscode
+.devcontainer
 data
-log
-logs
+log*
 pkg
 tmp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,33 @@
+# https://docs.rubocop.org/rubocop/configuration.html
+# inherit_from: ../.rubocop.yml
+# inherit_from:
+#   - http://<personal_access_token>@raw.github.com/example/rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 2.6, 2.7, 3.2
+  EnabledByDefault: false
+  NewCops: enable
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Layout/LineLength:
+  Enabled: true
+  Max: 120
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Layout/HashAlignment:
+  Enabled: false
+
+Lint/Void:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem 'rake', '>=13.0.6'
-
 # bundle install --without production
 # bundle install --with development
 # bundle install --without development

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,11 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
+gem 'rake', '>=13.0.6'
+
+# bundle install --without production
+# bundle install --with development
+# bundle install --without development
 group 'development' do
   gem 'byebug'
   gem 'pry'
@@ -11,5 +16,3 @@ group 'development' do
   gem 'rubocop'
   gem 'tryouts'
 end
-
-gem 'rake', '>=13.0.6'

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # bundle install --without production
 # bundle install --with development
 # bundle install --without development
-group 'development' do
-  gem 'byebug'
-  gem 'pry'
-  gem 'pry-doc'
-  gem 'rubocop'
-  gem 'tryouts'
+group "development" do
+  gem "byebug"
+  gem "pry"
+  gem "pry-doc"
+  gem "rubocop"
+  gem "tryouts"
 end

--- a/README.md
+++ b/README.md
@@ -76,6 +76,69 @@ or via download:
 * [attic-latest.zip](https://github.com/delano/attic/zipball/latest)
 
 
+## Proofs
+
+Tested the following code in IRB for Ruby 2.6.8 and 3.0.2:
+
+```ruby
+    rquire 'pp'
+
+    test_values = [:sym, 1, 1.01, Symbol, Integer, Float, String, TrueClass, FalseClass, NilClass, '', true, false, nil]
+
+    results = test_values.map do |value|
+      { value: value,
+        class: value.class,
+        attic: [value.attic?, value.attic? && value.attic.object_id] }
+    end
+```
+
+which produced the same results for both.
+
+```ruby
+    attic> RUBY_VERSION
+    => "3.2.0"
+
+    pp results
+    [
+      {:value=>:sym,        :class=>Symbol,       :attic=>[false, false]},
+      {:value=>1,           :class=>Integer,      :attic=>[false, false]},
+      {:value=>1.01,        :class=>Float,        :attic=>[false, false]},
+      {:value=>Symbol,      :class=>Class,        :attic=>[true, 564680]},
+      {:value=>Integer,     :class=>Class,        :attic=>[true, 564700]},
+      {:value=>Float,       :class=>Class,        :attic=>[true, 564720]},
+      {:value=>String,      :class=>Class,        :attic=>[true, 564740]},
+      {:value=>TrueClass,   :class=>Class,        :attic=>[true, 564760]},
+      {:value=>FalseClass,  :class=>Class,        :attic=>[true, 564780]},
+      {:value=>NilClass,    :class=>Class,        :attic=>[true, 564800]},
+      {:value=>"",          :class=>String,       :attic=>[true, 602880]}
+      {:value=>true,        :class=>TrueClass,    :attic=>[true, 13840]},
+      {:value=>false,       :class=>FalseClass,   :attic=>[true, 13860]},
+      {:value=>nil,         :class=>NilClass,     :attic=>[true, 40]}
+    ]
+```
+```ruby
+    attic> RUBY_VERSION
+    => "2.6.8"
+
+    pp results
+    [
+      {:value=>:sym,        :class=>Symbol,       :attic=>[false, false]},
+      {:value=>1,           :class=>Integer,      :attic=>[false, false]},
+      {:value=>1.01,        :class=>Float,        :attic=>[false, false]},
+      {:value=>Symbol,      :class=>Class,        :attic=>[true, 2844115920]},
+      {:value=>Integer,     :class=>Class,        :attic=>[true, 2844089400]},
+      {:value=>Float,       :class=>Class,        :attic=>[true, 2844087700]},
+      {:value=>String,      :class=>Class,        :attic=>[true, 2844122580]},
+      {:value=>TrueClass,   :class=>Class,        :attic=>[true, 2844136260]},
+      {:value=>FalseClass,  :class=>Class,        :attic=>[true, 2844136000]},
+      {:value=>NilClass,    :class=>Class,        :attic=>[true, 2844139060]},
+      {:value=>"",          :class=>String,       :attic=>[true, 2845261220]},
+      {:value=>true,        :class=>TrueClass,    :attic=>[true, 2844136280]},
+      {:value=>false,       :class=>FalseClass,   :attic=>[true, 2844136020]},
+      {:value=>nil,         :class=>NilClass,     :attic=>[true, 2844139080]}
+    ]
+```
+
 ## Credits
 
 * (@delano) Delano Mandelbaum

--- a/attic.gemspec
+++ b/attic.gemspec
@@ -1,6 +1,6 @@
 @spec = Gem::Specification.new do |s|
 	s.name = "attic"
-	s.version = "0.6-RC1"
+	s.version = "0.9-RC1"
 	s.summary = "When in doubt, store it in the attic"
 	s.description = "Attic: a place to hide metadata about the class or variable itself (e.g. SHA hash summaries)."
 	s.author = "Delano Mandelbaum"
@@ -11,6 +11,10 @@
   s.extra_rdoc_files = %w[README.md]
   s.licenses = ["MIT"]  # https://spdx.org/licenses/MIT-Modern-Variant.html
   s.rdoc_options = ["--line-numbers", "--title", s.summary, "--main", "README.md"]
+  s.required_ruby_version = ">= 2.6.0"
+  s.dependencies = [
+    ["rake", ">=13.0.6"]
+  ]
   s.files = %w(
     README.md
     Rakefile

--- a/attic.gemspec
+++ b/attic.gemspec
@@ -1,20 +1,18 @@
 @spec = Gem::Specification.new do |s|
-	s.name = "attic"
-	s.version = "0.9-RC1"
-	s.summary = "When in doubt, store it in the attic"
-	s.description = "Attic: a place to hide metadata about the class or variable itself (e.g. SHA hash summaries)."
-	s.author = "Delano Mandelbaum"
-	s.email = "gems@solutious.com"
-	s.homepage = "https://github.com/delano/attic"
+  s.name = "attic"
+  s.version = "0.9-RC1"
+  s.summary = "When in doubt, store it in the attic"
+  s.description = "Attic: a place to hide metadata about the class or variable itself (e.g. SHA hash summaries)."
+  s.author = "Delano Mandelbaum"
+  s.email = "gems@solutious.com"
+  s.homepage = "https://github.com/delano/attic"
   s.executables = %w[]
   s.require_paths = %w[lib]
   s.extra_rdoc_files = %w[README.md]
   s.licenses = ["MIT"]  # https://spdx.org/licenses/MIT-Modern-Variant.html
   s.rdoc_options = ["--line-numbers", "--title", s.summary, "--main", "README.md"]
   s.required_ruby_version = ">= 2.6.0"
-  s.dependencies = [
-    ["rake", ">=13.0.6"]
-  ]
+  s.add_dependency "rake", ">=13.0.6"
   s.files = %w(
     README.md
     Rakefile

--- a/lib/attic.rb
+++ b/lib/attic.rb
@@ -1,8 +1,8 @@
 # Attic: A special place to store instance variables.
 
-require 'attic/class_methods'
-require 'attic/errors'
-require 'attic/instance_methods'
+require_relative "attic/class_methods"
+require_relative "attic/errors"
+require_relative "attic/instance_methods"
 
 # = Attic
 #

--- a/lib/attic.rb
+++ b/lib/attic.rb
@@ -1,5 +1,9 @@
 # Attic: A special place to store instance variables.
 
+require 'attic/class_methods'
+require 'attic/errors'
+require 'attic/instance_methods'
+
 # = Attic
 #
 # == Usage:

--- a/lib/attic.rb
+++ b/lib/attic.rb
@@ -4,100 +4,93 @@
 #
 class NoSingleton < RuntimeError
   unless defined?(MEMBERS)
-    # An Array of classes which do not have singleton classes
+    # A Set of classes which do not have singleton classes
     # (i.e. meta classes). This is used to prevent an exception
-    # the first time a metaclass is accessed. It's populated
+    # the first time an attic is accessed. It's populated
     # dynamically at start time by simply checking whether
-    # the object has a singleton. This only needs to be done
-    # once per class.
+    # the object has a singleton. This only needs to be
+    # done once per class.
     #
-    MEMBERS = Set.new # rubocop:disable Style/MutableConstant
+    # We use a set here to avoid having to deal with duplicate
+    # values. Realistically there are only a few classes that
+    # do not have singleton classes. We could hard code them
+    # here which is not lost on us.
+    #
+    MEMBERS = Set.new
   end
 
-
-end
-
-# = AtticObjectMethods
-#
-# Adds a few methods for accessing the metaclass of an
-# object. We do this with great caution since the Object
-# class is as global as it gets in Ruby.
-#
-# NOTE: This module can be included in the Object class
-module AtticObjectMethods
-
-  # A quick way to check if the current object already has a
-  # dedicated singleton class. We want to know this because
-  # this is where our attic variables will be stored.
-  def attic?
-    return false if NoSingleton::MEMBERS === self
-
-    # NOTE: Calling this on an object for the first time lazily
-    # creates a singleton class for itself. Another way of doing
-    # the same thing is to attempt defining a singleton method
-    # for the object. In either case, and exception is raised
-    # if the object cannot have a dedicated singleton class.
-    !self.singleton_class.nil?
-
-  rescue TypeError
-    NoSingleton::MEMBERS.merge [self]
-    false
+  # Check if the given object is a member of the NoSingleton
+  # members list. This checks for the object itself and all
+  # of its ancestors. See the docs for `Enumerable#===` for
+  # more details.
+  def self.member?(obj)
+    MEMBERS === obj
   end
 
-  def attic
-    raise NoSingleton, self, caller unless self.attic?
-
-    self.singleton_class
-
-  rescue TypeError
-    NoSingleton::MEMBERS.merge [self]
-  end
-
-  # A convenient method for getting the metaclass of the current object.
-  # i.e.
-  #
-  #     class << self; self; end;
-  #
-  # NOTE: Some Ruby class do not have meta classes (see: MEMBERS).
-  # For these classes, this method returns the class itself. That means
-  # the instance variables will be stored in the class itself.
-  def metaclass
-    if self.attic?
-      class << self
-        pp 1
-        self
-      end
-    else
-      pp 2
-      self
-    end
-  end
-
-  # A convenience method for ensuring that the metaclass of the current
-  # object is returned.
-  # def attic
-  #   klass = self.class
-  #   variable_name = "@@_attic_#{object_id}"
-
-  #   unless klass.class_variable_defined?(variable_name)
-  #     klass.class_variable_set(variable_name, klass.singleton_class)
-  #   end
-
-  #   klass.class_variable_get variable_name
-  # end
-
-  # Add an instance method called +name+ to metaclass for the current object.
-  # This is useful because it will be available as a singleton method
-  # to all subclasses too.
-  def meta_def(name, &blk)
-    meta_eval { define_method name, &blk }
+  def self.add_member(obj)
+    MEMBERS.merge [self]
   end
 end
-
 
 # = Attic
 #
-# A place to store instance variables.
+# Usage:
+#  require 'attic'
+#  class MyClass
+#    include Attic
+#   attic :name, :age
+#  end
+#
+#
+#
+#
+# A few important notes: some objects are not capable of
+# constructing an attic. These are objects that do not have
+# a dedicated singleton class.
+#
+#
+# Calling attic on `Symbol, Integer, Float` are what ruby
+# internals refer to as "immediate values". They're special
+# in that they are not objects in the traditional sense.
+# They're just values (they're not even instances of a
+# class 😮‍💨).
+#
+# :sym.attic       #=> raises NoSingleton error
+# 1.attic          #=> Ditto
+# 1.0.1.attic      #=> Ditto again
+#
+#
+# Calling attic on `true, false, and nil` return their
+# class. Note: this means that they all share the same
+# "attic" class.
+#
+# true.attic       #=> TrueClass
+# false.attic      #=> FalseClass
+# nil.attic        #=> NilClass
+#
+#
+# The behaviour is similar with NilClass, TrueClass,
+# and FalseClass. Calling attic on these classes returns
+# a singleton class for each of them but again they all
+#
+# TrueClass.attic  #=> #<Class:TrueClass>
+# FalseClass.attic #=> #<Class:FalseClass>
+# NilClass.attic   #=> #<Class:NilClass>
+#
+#
+# For comparison, here's what happens with a String (each
+# time attic is called on a new string you get a new
+# singleton)
+#
+# "".attic         #=> #<Class:#<String:0x0001234>>
+# "".attic         #=> #<Class:#<String:0x0005678>>
+# "".attic.object_id #=> 1234
+# "".attic.object_id #=> 5678
+#
+# nil.attic        #=> NilClass
+# nil.attic        #=> NilClass
+# nil.attic.object_id #=> 800
+# nil.attic.object_id #=> 800
 #
 module Attic
   VERSION = '0.6-RC1'.freeze unless defined?(VERSION)
@@ -105,62 +98,152 @@ module Attic
   # = Attic::InstanceMethods
   #
   module InstanceMethods
-    def attic_variables
-      self.class.attic_variables
-    end
-    alias attic_vars attic_variables
+    # def attic_variables
+    #   self.class.attic_variables
+    # end
+    # alias attic_vars attic_variables
 
-    def attic_variable? name
-      self.class.attic_variable? name
+    # def attic_variable?(name)
+    #   self.class.attic_variable? name
+    # end
+    # alias attic_var? attic_variable?
+
+    # def attic_variable_set(name, val)
+    #   attic_variables << name unless attic_variable? name
+    #   attic.instance_variable_set("@___attic_#{name}", val)
+    # end
+    # alias attic_var_set attic_variable_set
+
+    # def attic_variable_get(name)
+    #   attic.instance_variable_get("@___attic_#{name}")
+    # end
+    # alias attic_var_get attic_variable_get
+  end
+
+  # = Attic::ConstructionMethods
+  #
+  # Adds a few methods for accessing the metaclass of an
+  # object. We do this with great caution since the Object
+  # class is as global as it gets in Ruby.
+  #
+  module ClassMethods
+    # A list of all the attic variables defined for this class.
+    attr_reader :attic_variables
+
+    # A quick way to check if the current object already has a
+    # dedicated singleton class. We want to know this because
+    # this is where our attic variables will be stored.
+    def attic?
+      return false if NoSingleton.member? self
+
+      # NOTE: Calling this on an object for the first time lazily
+      # creates a singleton class for itself. Another way of doing
+      # the same thing is to attempt defining a singleton method
+      # for the object. In either case, and exception is raised
+      # if the object cannot have a dedicated singleton class.
+      !self.singleton_class.nil?
+
+    rescue TypeError
+      # Remember for next time.
+      NoSingleton.add_member self
+      false
+    end
+
+    def attic(name)
+      name = name.normalize
+
+      self.attic_variables << name unless attic_variable? name
+
+      _safe_name = "@_attic_#{name}"
+      instance_variable_set(_safe_name, name)
+    end
+
+    def attic_variable?(name)
+      attic_variables.include? name.normalize
     end
 
     def attic_variable_set(name, val)
-      attic_variables << name unless attic_variable? name
-      attic.instance_variable_set("@___attic_#{name}", val)
+      unless attic_variable? name
+        self.attic_variables << name.normalize
+      end
+      attic.instance_variable_set("@_attic_#{name}", val)
     end
 
     def attic_variable_get(name)
-      attic.instance_variable_get("@___attic_#{name}")
+      instance_variable_get("@_attic_#{name}")
     end
 
-    def get_binding
-      binding
+    protected
+
+    def normalize(name)
+      name.to_s.gsub(/\@[\?\!\=]$/, '_').to_sym
     end
+    # def attic
+    #   raise NoSingleton, self, caller unless attic?
+    #
+    #   singleton_class
+    #
+    # rescue TypeError
+    #   NoSingleton.add_member self
+    # end
   end
 
-  def self.attic_variables
-    @attic_variables
+  # A convenince method at the class level for including
+  # ConstructMethods in the given object specifically.
+  #
+  #   e.g.
+  #
+  #     Add Attic support to all objects available now and
+  #     in the future:
+  #
+  #       Attic.construct(Object)
+  #
+  #     which is equivalent to:
+  #
+  #       class Object; include AtticObjectMethods; end
+  #
+  def self.construct(obj)
+    obj.include AtticObjectMethods
   end
 
-  def self.included(o)
-    raise "You probably meant to 'extend Attic' in #{o}"
+  def self.included(obj)
+    raise Runtime, "Did you to `extend Attic`` in #{obj}"
   end
 
-  def self.extended(o)
-    # This class has already been extended.
-    return if o.ancestors.member? Attic::InstanceMethods
+  def self.extended(obj)
+    # If the class has already been extended, we don't need
+    # to add the class methods again.
+    return if obj.ancestors.member? self
 
     # Add the instance methods for accessing attic variables
-    o.send :include, Attic::InstanceMethods
+    obj.send :include, Attic::InstanceMethods
 
-    o.metaclass.instance_variable_set("@attic_variables", [])
-    o.class_eval do
-      def self.inherited(klass)
-        attic_vars = self.attic_variables.clone
-        klass.metaclass.instance_variable_set("@attic_variables", attic_vars)
+    # If the object doesn't have a dedicated singleton class
+    # an exception will be raised so it can be caught and
+    # handled appropriately.
+    obj.attic.instance_variable_defined?("@attic_variables")
+
+    obj.attic.instance_variable_set("@attic_variables", [])
+
+    def obj.inherited(klass)
+      super
+      attic_vars = self.attic_variables.clone
+      klass.attic.instance_variable_set("@attic_variables", attic_vars)
+    end
+    if method_defined? :instance_variables
+      instance_variables_orig = instance_method(:instance_variables)
+      define_method :instance_variables do
+        ret = _instance_variables_orig.bind(self).call.clone
+        ret.reject! { |v| v.to_s =~ /^@___?attic/ }  # match 2 or 3 underscores
+        ret
       end
-      if method_defined? :instance_variables
-        _instance_variables_orig = instance_method(:instance_variables)
-        define_method :instance_variables do
-          ret = _instance_variables_orig.bind(self).call.clone
-          ret.reject! { |v| v.to_s =~ /^@___?attic/ }  # match 2 or 3 underscores
-          ret
-        end
-        define_method :all_instance_variables do
-          _instance_variables_orig.bind(self).call
-        end
+      define_method :all_instance_variables do
+        _instance_variables_orig.bind(self).call
       end
     end
+
+  rescue TypeError => e
+    raise NoSingleton, obj, caller
   end
 
   # A class method for defining variables to store in the attic.
@@ -168,7 +251,7 @@ module Attic
   #   created for each variable name in the list.
   #
   # Returns the list of attic variable names or if no names were
-  # given, returns the metaclass.
+  # given, returns the attic.
   #
   # e.g.
   #
@@ -179,8 +262,9 @@ module Attic
   # * <tt>String#timestamp</tt> for getting the value
   # * <tt>String#timestamp</tt> for setting the value
   #
-  def attic *names
-    return metaclass if names.empty?
+  def attic(*names)
+    return attic_variables if names.empty?
+
     names.each do |name|
       next if attic_variable? name
 
@@ -198,7 +282,8 @@ module Attic
         end
       end
     end
-    attic_vars
+
+    attic_variables
   end
 
   # Returns an Array of attic variables for the current class.
@@ -209,8 +294,8 @@ module Attic
   #     String.attic_variables     # => [:timestamp]
   #
   def attic_variables
-    a = metaclass.instance_variable_get('@attic_variables')
-    a ||= metaclass.instance_variable_set('@attic_variables', [])
+    a = attic.instance_variable_get('@attic_variables')
+    a ||= attic.instance_variable_set('@attic_variables', [])
     a
   end
   alias attic_vars attic_variables

--- a/lib/attic/class_methods.rb
+++ b/lib/attic/class_methods.rb
@@ -1,8 +1,7 @@
 #
 # = Attic::ClassMethods
 #
-class Attic
-
+module Attic
   # Adds a few methods for accessing the metaclass of an
   # object. We do this with great caution since the Object
   # class is as global as it gets in Ruby.

--- a/lib/attic/class_methods.rb
+++ b/lib/attic/class_methods.rb
@@ -1,0 +1,70 @@
+#
+# = Attic::ClassMethods
+#
+class Attic
+
+  # Adds a few methods for accessing the metaclass of an
+  # object. We do this with great caution since the Object
+  # class is as global as it gets in Ruby.
+  module ClassMethods
+    # A list of all the attic variables defined for this class.
+    attr_reader :attic_variables
+
+    # A quick way to check if the current object already has a
+    # dedicated singleton class. We want to know this because
+    # this is where our attic variables will be stored.
+    def attic?
+      return false if NoSingleton.member? self
+
+      # NOTE: Calling this on an object for the first time lazily
+      # creates a singleton class for itself. Another way of doing
+      # the same thing is to attempt defining a singleton method
+      # for the object. In either case, and exception is raised
+      # if the object cannot have a dedicated singleton class.
+      !self.singleton_class.nil?
+
+    rescue TypeError
+      # Remember for next time.
+      NoSingleton.add_member self
+      false
+    end
+
+    def attic(name)
+      name = name.normalize
+
+      self.attic_variables << name unless attic_variable? name
+
+      _safe_name = "@_attic_#{name}"
+      instance_variable_set(_safe_name, name)
+    end
+
+    def attic_variable?(name)
+      attic_variables.include? name.normalize
+    end
+
+    def attic_variable_set(name, val)
+      unless attic_variable? name
+        attic_variables << name.normalize
+      end
+      attic.instance_variable_set("@_attic_#{name}", val)
+    end
+
+    def attic_variable_get(name)
+      instance_variable_get("@_attic_#{name}")
+    end
+
+    protected
+
+    def normalize(name)
+      name.to_s.gsub(/\@[\?\!\=]$/, '_').to_sym
+    end
+    # def attic
+    #   raise NoSingleton, self, caller unless attic?
+    #
+    #   singleton_class
+    #
+    # rescue TypeError
+    #   NoSingleton.add_member self
+    # end
+  end
+end

--- a/lib/attic/errors.rb
+++ b/lib/attic/errors.rb
@@ -1,0 +1,49 @@
+
+# Attic: A special place to store instance variables.
+
+# = NoSingletonError
+#
+# This error is raised when an attempt is made to access the
+# attic of an object which does not have a singleton class.
+#
+# This is a RuntimeError because it is not an exceptional
+# condition. It is simply a condition that is not supported
+# by the Attic module.
+#
+# == Usage
+#
+#   require 'attic'
+#   class MyClass
+#     include Attic
+#     attic :name, :age
+#   end
+#
+class NoSingletonError < RuntimeError
+  unless defined?(MEMBERS)
+    # A Set of classes which do not have singleton classes
+    # (i.e. meta classes). This is used to prevent an exception
+    # the first time an attic is accessed. It's populated
+    # dynamically at start time by simply checking whether
+    # the object has a singleton. This only needs to be
+    # done once per class.
+    #
+    # We use a set here to avoid having to deal with duplicate
+    # values. Realistically there are only a few classes that
+    # do not have singleton classes. We could hard code them
+    # here which is not lost on us.
+    #
+    MEMBERS = Set.new
+  end
+
+  # Check if the given object is a member of the NoSingleton
+  # members list. This checks for the object itself and all
+  # of its ancestors. See the docs for `Enumerable#===` for
+  # more details.
+  def self.member?(obj)
+    MEMBERS === obj
+  end
+
+  def self.add_member(obj)
+    MEMBERS.merge [self]
+  end
+end

--- a/lib/attic/instance_methods.rb
+++ b/lib/attic/instance_methods.rb
@@ -2,8 +2,7 @@
 
 # = Attic::InstanceMethods
 #
-class Attic
-
+module Attic
   # Adds a few methods for object instances to access the
   # attic variables of their class.
   module InstanceMethods

--- a/lib/attic/instance_methods.rb
+++ b/lib/attic/instance_methods.rb
@@ -1,0 +1,31 @@
+#
+
+# = Attic::InstanceMethods
+#
+class Attic
+
+  # Adds a few methods for object instances to access the
+  # attic variables of their class.
+  module InstanceMethods
+    # def attic_variables
+    #   self.class.attic_variables
+    # end
+    # alias attic_vars attic_variables
+
+    # def attic_variable?(name)
+    #   self.class.attic_variable? name
+    # end
+    # alias attic_var? attic_variable?
+
+    # def attic_variable_set(name, val)
+    #   attic_variables << name unless attic_variable? name
+    #   attic.instance_variable_set("@___attic_#{name}", val)
+    # end
+    # alias attic_var_set attic_variable_set
+
+    # def attic_variable_get(name)
+    #   attic.instance_variable_get("@___attic_#{name}")
+    # end
+    # alias attic_var_get attic_variable_get
+  end
+end

--- a/try/30_nometaclass_tryouts.rb
+++ b/try/30_nometaclass_tryouts.rb
@@ -1,13 +1,13 @@
 require 'attic'
 
 ## has list of no metaclass classes
-Object::NOMETACLASS
+NoSingleton::MEMBERS
 #=> [Symbol, Integer]
 
 ## Symbol metaclass does not raise an exception
 begin
   :any.metaclass.class
-rescue NoMetaClass
+rescue NoSingleton
   :failed
 end
 #=> Class
@@ -20,13 +20,13 @@ a.name = :roger
 [a.name, b.name]
 #=> [:roger, nil]
 
-## metaclass? method exists
+## attic? method exists
 Symbol.extend Attic
-:any.respond_to? :metaclass?
+:any.respond_to? :attic?
 #=> true
 
-## metaclass? method is false for a Symbol", false do
-:any.metaclass?
+## attic? method is false for a Symbol", false do
+:any.attic?
 #=> false
 
 ## A Symbol's attic vars appear in `all_instance_variables` do


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
- The `Attic` module in `lib/attic.rb` was refactored to use `require_relative` for including `class_methods`, `errors`, and `instance_methods`. The `NoMetaClass` class and the `Object` class modifications were removed. The `VERSION` constant was added to the `Attic` module. The `construct` class method was added to the `Attic` module. The `attic` method was removed from the `Attic` module.
- The `ClassMethods` module was added to the `Attic` module in `lib/attic/class_methods.rb`. The `attic_variables` attribute reader was added to the `ClassMethods` module. The `attic?`, `attic`, `attic_variable?`, `attic_variable_set`, and `attic_variable_get` methods were added to the `ClassMethods` module.
- The `NoSingletonError` class was added in `lib/attic/errors.rb`. The `MEMBERS` constant was added to the `NoSingletonError` class. The `member?` and `add_member` class methods were added to the `NoSingletonError` class.
- The `version` attribute of the gem specification was updated in `attic.gemspec`. The `required_ruby_version` and `add_dependency` attributes were added to the gem specification.
- The `30_nometaclass_tryouts.rb` test file in `try/` was updated. `Object::NOMETACLASS` was replaced with `NoSingleton::MEMBERS`. `NoMetaClass` was replaced with `NoSingleton`. `metaclass?` was replaced with `attic?`. `metaclass?` was replaced with `attic?`.
- The `InstanceMethods` module was added to the `Attic` module in `lib/attic/instance_methods.rb`.
- A "Proofs" section with example code and results was added to the README in `README.md`.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>attic.rb</strong><dd><code>Refactor and update the `Attic` module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/attic.rb
- Refactored the `Attic` module to use `require_relative` for including <br>  `class_methods`, `errors`, and `instance_methods`.
- Updated the `Attic` module's documentation.
- Removed the `NoMetaClass` class and the `Object` class modifications.
- Added the `VERSION` constant to the `Attic` module.
- Added the `construct` class method to the `Attic` module.
- Removed the `attic` method from the `Attic` module.
    </details>
  </td>
  <td><a href="https://github.com/delano/attic/pull/2/files#diff-4b96430fccf80a12faf68b11ac2b8ec01c0144939405ca1aadc6da42391aa24a">+148/-147</a></td>
</tr>                    
</table></td></tr><tr><td><strong>New feature</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>class_methods.rb</strong><dd><code>Add the `ClassMethods` module to the `Attic` module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/attic/class_methods.rb
- Added the `ClassMethods` module to the `Attic` module.
- Added the `attic_variables` attribute reader to the `ClassMethods` <br>  module.
- Added the `attic?`, `attic`, `attic_variable?`, `attic_variable_set`, `<br>  `and `<br>  ``attic_variable_get` <br>  methods to the `ClassMethods` module.
    </details>
  </td>
  <td><a href="https://github.com/delano/attic/pull/2/files#diff-5638badbd66f0b4fe8e3d149134efcec947a89492ccd47eea1e34fecebe2e31f">+69/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>instance_methods.rb</strong><dd><code>Add the `InstanceMethods` module to the `Attic` module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/attic/instance_methods.rb
- Added the `InstanceMethods` module to the `Attic` module.
    </details>
  </td>
  <td><a href="https://github.com/delano/attic/pull/2/files#diff-d3be9d46cc7eedb0a2a953c451c5fb0cd5d14d158e1988fd088f0befd34da881">+30/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>errors.rb</strong><dd><code>Add the `NoSingletonError` class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/attic/errors.rb
- Added the `NoSingletonError` class.
- Added the `MEMBERS` constant to the `NoSingletonError` class.
- Added the `member?` and `add_member` class methods to the <br>  `NoSingletonError` class.
    </details>
  </td>
  <td><a href="https://github.com/delano/attic/pull/2/files#diff-02edfdda5c43e4fe13c069af028fc2068e77b0aa7172996130e61dc42d019a35">+49/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>attic.gemspec</strong><dd><code>Update the gem specification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

attic.gemspec
- Updated the `version` attribute of the gem specification.
- Added the `required_ruby_version` and `add_dependency` attributes to <br>  the gem specification.
    </details>
  </td>
  <td><a href="https://github.com/delano/attic/pull/2/files#diff-29b0d9ffdf84fd142af18bbf35a9ca9a79ffee2992800ffadfc300a2fc7f1b73">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>30_nometaclass_tryouts.rb</strong><dd><code>Update the `30_nometaclass_tryouts.rb` test file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/30_nometaclass_tryouts.rb
- Replaced `Object::NOMETACLASS` with `NoSingleton::MEMBERS`.
- Replaced `NoMetaClass` with `NoSingleton`.
- Replaced `metaclass?` with `attic?`.
- Replaced `metaclass?` with `attic?`.
    </details>
  </td>
  <td><a href="https://github.com/delano/attic/pull/2/files#diff-7e8c8c47e1efd9452cc4434b6cb430b6945db615676e66b059395bee45d6f5d4">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update the README with a "Proofs" section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md
- Added a "Proofs" section with example code and results.
    </details>
  </td>
  <td><a href="https://github.com/delano/attic/pull/2/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+63/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
